### PR TITLE
mako: Fix mismerge

### DIFF
--- a/init.mako.rc
+++ b/init.mako.rc
@@ -285,9 +285,6 @@ on post-fs-data
     # disable diag port
     rm /dev/diag
 
-    # disable diag port
-    rm /dev/diag
-
 on charger
     # Enable Power modes and set the CPU Freq Sampling rates
     write /sys/module/rpm_resources/enable_low_power/L2_cache 1


### PR DESCRIPTION
Duplicate "disable diag port".
See android.googlesource.com/device/lge/mako/+/3ac5654c0a144eda4925c70e5c2f275e95c31e7c/init.mako.rc

Change-Id: I42932760217219b254c7bb912178d0672b04d2c2