### PR TITLE
Revert "mako: Enable QRNGD"

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -282,9 +282,6 @@ PRODUCT_PACKAGES += \
     libOmxEvrcEnc \
     libOmxQcelp13Enc
 
-# QRNGD
-PRODUCT_PACKAGES += qrngd
-
 $(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
 
 # This is the mako-specific audio package

--- a/init.mako.rc
+++ b/init.mako.rc
@@ -475,11 +475,6 @@ service diag_mdlog /system/bin/diag_mdlog -s 100
     class late_start
     disabled
 
-service qrngd /system/bin/qrngd -f
-    class main
-    user root
-    group root
-
 # CyanogenMod Performance Profiles
 # Powersave
 on property:sys.perf.profile=0


### PR DESCRIPTION
This reverts commit bff6fc9fd6265a3ab93c4af30443ef39f0e29844.

Change-Id: I29f80e992e3a6842c746548d7cd39d9c59637df9