### PR TITLE
Revert "Enable clang"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -52,9 +52,6 @@ BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/lge/mako/bluetooth
 # Use the CM PowerHAL
 TARGET_USES_CM_POWERHAL := true
 
-# Use clang
-USE_CLANG_PLATFORM_BUILD := true
-
 # FIXME: HOSTAPD-derived wifi driver
 BOARD_HAS_QCOM_WLAN := true
 BOARD_WLAN_DEVICE := qcwcn


### PR DESCRIPTION
Sensors break on clang

This reverts commit ba4e09411197239c0db8ab0556d896d62e25ad15.

Change-Id: I83574ff019176127ab086d1af5f8d9f9be18981c