### PR TITLE
mako: Cleanup device.mk

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -21,15 +21,10 @@
 
 DEVICE_PACKAGE_OVERLAYS := device/lge/mako/overlay
 
-# This device is xhdpi.  However the platform doesn't
-# currently contain all of the bitmaps at xhdpi density so
-# we do this little trick to fall back to the hdpi version
-# if the xhdpi doesn't exist.
-PRODUCT_AAPT_CONFIG := normal hdpi xhdpi
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 PRODUCT_PACKAGES := \
-	lights.mako \
+    lights.mako \
     libwpa_client \
     hostapd \
     dhcpcd.conf \
@@ -150,14 +145,6 @@ PRODUCT_PROPERTY_OVERRIDES += persist.hwc.mdpcomp.enable=true
 PRODUCT_CHARACTERISTICS := nosdcard
 
 PRODUCT_PACKAGES += \
-	librs_jni \
-	com.android.future.usb.accessory
-
-# Filesystem management tools
-PRODUCT_PACKAGES += \
-	e2fsck
-
-PRODUCT_PACKAGES += \
 	libgenlock \
 	liboverlay \
 	hwcomposer.msm8960 \
@@ -251,8 +238,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 endif
 
 PRODUCT_PROPERTY_OVERRIDES += \
-	wifi.interface=wlan0 \
-	wifi.supplicant_scan_interval=15
+    wifi.interface=wlan0
 
 # Enable AAC 5.1 output
 PRODUCT_PROPERTY_OVERRIDES += \
@@ -268,9 +254,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # IO Scheduler
 PRODUCT_PROPERTY_OVERRIDES += \
 	sys.io.scheduler=bfq
-
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-	persist.sys.usb.config=mtp
 
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.dex2oat-filter=speed \


### PR DESCRIPTION
PS 1-3
* delete obsolete entries
* don't copy items already copied by build

PS 4
* remove persist.sys.usb.config override
  The variable persist.sys.usb.config is no longer honored by the framework,
  and it's presence causes unnecessary toggling of the USB driver, which
  disonnects ADB and makes the device's connection unstable.

Change-Id: I0fc3c4c2cc0da71b6679032a515f3549bd17d63c