### PR TITLE
Mako: sprintf into snprintf to avoid overflow buffer memory issues

### DIFF
--- a/camera/QCamera/HAL/core/src/QCameraHWI_Parm.cpp
+++ b/camera/QCamera/HAL/core/src/QCameraHWI_Parm.cpp
@@ -438,14 +438,15 @@ void QCameraHardwareInterface::filterPictureSizes(){
 
 static String8 create_sizes_str(const camera_size_type *sizes, int len) {
     String8 str;
-    char buffer[32];
+    int bufSize = 32;
+    char buffer[bufSize];
 
     if (len > 0) {
-        snprintf(buffer, sizeof(buffer), "%dx%d", sizes[0].width, sizes[0].height);
+        snprintf(buffer, bufSize, "%dx%d", sizes[0].width, sizes[0].height);
         str.append(buffer);
     }
     for (int i = 1; i < len; i++) {
-        snprintf(buffer, sizeof(buffer), ",%dx%d", sizes[i].width, sizes[i].height);
+        snprintf(buffer, bufSize, ",%dx%d", sizes[i].width, sizes[i].height);
         str.append(buffer);
     }
     return str;
@@ -3448,7 +3449,8 @@ status_t QCameraHardwareInterface::setPreviewSizeTable(void)
     struct camera_size_type* preview_size_table;
     int preview_table_size;
     int i = 0;
-    char str[10] = {0};
+    int strSize = 10;
+    char str[strSize] = {0};
 
     /* Initialize table with default values */
     preview_size_table = default_preview_sizes;
@@ -3480,7 +3482,7 @@ status_t QCameraHardwareInterface::setPreviewSizeTable(void)
         preview_size_table++;
     }
     //set preferred preview size to maximum preview size
-    sprintf(str, "%dx%d", preview_size_table->width, preview_size_table->height);
+    snprintf(str, strSize, "%dx%d", preview_size_table->width, preview_size_table->height);
     mParameters.set(CameraParameters::KEY_PREFERRED_PREVIEW_SIZE_FOR_VIDEO, str);
     LOGD("KEY_PREFERRED_PREVIEW_SIZE_FOR_VIDEO = %s", str);
 

--- a/camera/QualcommCameraHardware.cpp
+++ b/camera/QualcommCameraHardware.cpp
@@ -905,14 +905,15 @@ static yv12_format_parms_t myv12_params;
 
 static String8 create_sizes_str(const camera_size_type *sizes, int len) {
     String8 str;
-    char buffer[32];
+    int bufSize = 32;
+    char buffer[bufSize];
 
     if (len > 0) {
-        sprintf(buffer, "%dx%d", sizes[0].width, sizes[0].height);
+        snprintf(buffer, bufSize,"%dx%d", sizes[0].width, sizes[0].height);
         str.append(buffer);
     }
     for (int i = 1; i < len; i++) {
-        sprintf(buffer, ",%dx%d", sizes[i].width, sizes[i].height);
+        snprintf(buffer, bufSize,",%dx%d", sizes[i].width, sizes[i].height);
         str.append(buffer);
     }
     return str;
@@ -920,14 +921,15 @@ static String8 create_sizes_str(const camera_size_type *sizes, int len) {
 
 static String8 create_fps_str(const android:: FPSRange* fps, int len) {
     String8 str;
-    char buffer[32];
+    int bufSize = 32;
+    char buffer[bufSize];
 
     if (len > 0) {
-        sprintf(buffer, "(%d,%d)", fps[0].minFPS, fps[0].maxFPS);
+        snprintf(buffer, bufSize,"(%d,%d)", fps[0].minFPS, fps[0].maxFPS);
         str.append(buffer);
     }
     for (int i = 1; i < len; i++) {
-        sprintf(buffer, ",(%d,%d)", fps[i].minFPS, fps[i].maxFPS);
+        snprintf(buffer, bufSize,",(%d,%d)", fps[i].minFPS, fps[i].maxFPS);
         str.append(buffer);
     }
     return str;
@@ -3491,8 +3493,9 @@ void QualcommCameraHardware::runVideoThread(void *data)
 #if 0
             static int frameCnt = 0;
             if (frameCnt >= 11 && frameCnt <= 13 ) {
-                char buf[128];
-                sprintf(buf,  "/data/%d_v.yuv", frameCnt);
+                int bufSize=128
+                char buf[bufSize];
+                snprintf(buf, bufSize, "/data/%d_v.yuv", frameCnt);
                 int file_fd = open(buf, O_RDWR | O_CREAT, 0777);
                 ALOGV("dumping video frame %d", frameCnt);
                 if (file_fd < 0) {

--- a/conn_init/wfc_util_fctrl.c
+++ b/conn_init/wfc_util_fctrl.c
@@ -418,7 +418,7 @@ void wfc_util_fset_string(char *pFileName, char *pEndOfCfg, char *pSTagString, c
 					 * prefare the new string to insert
 					 */
 					memset( pNewValueBuff, 0, sz_NewValueBuff );
-					sprintf( pNewValueBuff, "%c%s%s%s%c", '\n', pSTagString, pNewValueString, pETagString,'\n' );
+					snprintf( pNewValueBuff, sz_NewValueBuff,"%c%s%s%s%c", '\n', pSTagString, pNewValueString, pETagString,'\n' );
 
 					/*
 					 * insert new string to the file

--- a/liblight/lights.c
+++ b/liblight/lights.c
@@ -83,8 +83,9 @@ write_int(char const* path, int value)
 
     fd = open(path, O_RDWR);
     if (fd >= 0) {
-        char buffer[20];
-        int bytes = sprintf(buffer, "%d\n", value);
+        int bufSize = 20;
+        char buffer[bufSize];
+        int bytes = snprintf(buffer, bufSize, "%d\n", value);
         int amt = write(fd, buffer, bytes);
         close(fd);
         return amt == -1 ? -errno : 0;


### PR DESCRIPTION
C lang errors fix while D_FORTIFY_SOURCE strict mode D_FORTIFY_SOURCE=2

strict mode errors sprintf into snprintf To suppress C WARNINGS while building.
or To support -D_FORTIFY_SOURCE strict compilation under build system.

Change-Id: I7981c49bd13adc6d6e163bd5ad37c8696d623cae