### PR TITLE
Revert "Revert "mako: don't force build recorder app (for now)""

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -216,10 +216,6 @@ PRODUCT_PACKAGES += \
     ueventd.rc \
     ueventd.mako.rc
 
-# Recorder
-PRODUCT_PACKAGES += \
-    Recorder
-
 # RenderScript HAL
 PRODUCT_PACKAGES += \
     android.hardware.renderscript@1.0-impl


### PR DESCRIPTION
This reverts commit fe388a4aba6dcf0ef84e4094e4eaebe6b89a340c.

Even though recorder app can be useful for us, we'd rather save our system space for future gapps installations.

Change-Id: I0ad47ef7bf168c480b7958cbe4df97b30eb3b32b